### PR TITLE
Bug fix for Option.php class

### DIFF
--- a/src/Option.php
+++ b/src/Option.php
@@ -24,7 +24,7 @@ final class Option
 
     public function getErrorType(): string
     {
-        return $this->error_type;
+        return $this->error_type ?? 'error';
     }
 
     public function prepare(): self

--- a/tests/OptionTest.php
+++ b/tests/OptionTest.php
@@ -68,4 +68,16 @@ class OptionTest extends TestCase
         $this->assertNotRegExp("$regex", $log_file_content);
         $this->assertNotRegExp('!>>>!', $log_file_content);
     }
+
+    /** @test */
+    public function you_can_pass_option_without_error_type(): void
+    {
+        tiny_log('Nice text is here', 'pos');
+        $line_number = __LINE__ - 1;
+
+        $log_file_content = file_get_contents($this->file_name);
+
+        $regex = sprintf('!>>> %s on line: %d!', __FILE__, $line_number);
+        $this->assertRegExp("$regex", $log_file_content);
+    }
 }


### PR DESCRIPTION
* Before you couldn't pass option without error type like so:
tiny_log('Message is here', 'pos');
Now you can do that